### PR TITLE
Removed apache dbcp BasicDataSource as it's no longer needed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,11 +87,6 @@
             <version>42.5.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-dbcp</artifactId>
-            <version>9.0.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
             <version>${spring.version}</version>


### PR DESCRIPTION
The apache DataSource implementation was used in Hibernate configuring, after transition to Spring Data, this dependency should have been removed.